### PR TITLE
Support for post in and post not in query arguments

### DIFF
--- a/_wpm/core/Components/QueryPostType.php
+++ b/_wpm/core/Components/QueryPostType.php
@@ -605,12 +605,13 @@ class QueryPostType
      * Setter for post__in arguments
      *
      * @param  array   $post_ids
+     * 
      * @return $this
      */
     public function postIn($post_ids)
     {
-        if (is_array($ids)) {
-            $this->args['post__in'] = $ids;
+        if (is_array($post_ids)) {
+            $this->args['post__in'] = $post_ids;
         }
         return $this;
     }
@@ -619,12 +620,13 @@ class QueryPostType
      * Setter for post__not_in arguments
      *
      * @param  array   $post_ids
+     * 
      * @return $this
      */
     public function postNotIn($post_ids)
     {
-        if (is_array($ids)) {
-            $this->args['post__not_in'] = $ids;
+        if (is_array($post_ids)) {
+            $this->args['post__not_in'] = $post_ids;
         }
         return $this;
     }

--- a/_wpm/core/Components/QueryPostType.php
+++ b/_wpm/core/Components/QueryPostType.php
@@ -600,6 +600,34 @@ class QueryPostType
         }
         return $this;
     }
+
+    /**
+     * Setter for post__in arguments
+     *
+     * @param  array   $post_ids
+     * @return $this
+     */
+    public function postIn($post_ids)
+    {
+        if (is_array($ids)) {
+            $this->args['post__in'] = $ids;
+        }
+        return $this;
+    }
+
+    /**
+     * Setter for post__not_in arguments
+     *
+     * @param  array   $post_ids
+     * @return $this
+     */
+    public function postNotIn($post_ids)
+    {
+        if (is_array($ids)) {
+            $this->args['post__not_in'] = $ids;
+        }
+        return $this;
+    }
     
     
     /**


### PR DESCRIPTION
This PR adds support for `post__in` and `post__not_in` query arguments that both take an array of post IDs.